### PR TITLE
Allow for spaces in/around the command prefix

### DIFF
--- a/src/main/kotlin/com/github/mdashl/kda/commandhandler/CommandHandler.kt
+++ b/src/main/kotlin/com/github/mdashl/kda/commandhandler/CommandHandler.kt
@@ -85,7 +85,7 @@ object CommandHandler : ListenerAdapter() {
             return null
         }
 
-        val s = message.split(" ")[0]
+        val s = message.drop(prefix.length).trim().split(" ")[0]
 
         return commands.find { command -> command.aliases.any { s.equals(prefix + it, true) } }
     }


### PR DESCRIPTION
Currently, the `CommandHandler#findCommand` method retrieves the command name with this line:
```kotlin
val s = message.split(" ")[0]
```

However, this prevents using spaces in the command prefix, or allowing for an optional space after the prefix. I believe the following code change will work better, as it allows for both of the above.